### PR TITLE
Audio improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworkdog/cogs-client-react",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
- Fix for fade in not working for non-preloaded and ephemeral clips
- Use ID from play() to make sure play audio action options only affect latest playing instance

This now behaves identically for preloaded and non-preloaded clips.

It also means that the settings such as volume, fade and loop on a 'play audio' don't affect already playing clips.