### PR TITLE
Fix for weird issue where clips mark as stopped as soon as they're started

### DIFF
--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -220,7 +220,10 @@ export default function useAudioPlayer(
           }
         });
       } else {
-        player.stop();
+        Object.keys(activeClips).forEach((soundIdStr) => {
+          const soundId = parseInt(soundIdStr);
+          player.stop(soundId);
+        });
       }
     },
     [audioClipPlayers, updateActiveAudioClip]
@@ -261,7 +264,15 @@ export default function useAudioPlayer(
     [updateAudioClipPlayer, updateActiveAudioClip]
   );
 
-  const stopAllAudioClips = useCallback(() => Object.values(audioClipPlayers).forEach((clipPlayer) => clipPlayer.player.stop()), [audioClipPlayers]);
+  const stopAllAudioClips = useCallback(
+    () =>
+      Object.values(audioClipPlayers).forEach((clipPlayer) => {
+        if (Object.keys(clipPlayer.activeClips).length) {
+          clipPlayer.player.stop();
+        }
+      }),
+    [audioClipPlayers]
+  );
 
   const setAudioClipVolume = useCallback(
     (path: string, { volume, fade }: { volume: number; fade?: number }) => {

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -312,7 +312,6 @@ export default function useAudioPlayer(
     (clipPath: string, previousClip: InternalClipPlayer, newConfig: InternalClipPlayer['config']): InternalClipPlayer => {
       const clip = { ...previousClip, config: newConfig };
       if (previousClip.config.preload !== newConfig.preload) {
-        clip.player.stop();
         clip.player.unload();
         clip.player = createPlayer(clipPath, newConfig);
       }
@@ -331,7 +330,6 @@ export default function useAudioPlayer(
         );
         removedClips.forEach((file) => {
           const player = previousClipPlayers[file].player;
-          player.stop();
           player.unload();
           delete clipPlayers[file];
         });


### PR DESCRIPTION
These few lines took most of a day to figure out!!

The symptom is this: Sometimes when a clip was started it would immediately call the `stop` callback, even though the clip carried on playing. This causes all manner of oddities as things like pausing, stopping, setting volume don't work on the clip as we are no longer tracking it in `activeClips`.

After a lot of digging I found that if you call `stop()` on a Howl player which is in the `unloaded` state, it queues up the `stop` callback to fire once the Howl has loaded. This only affects HTML5 non-preloaded clips. Due to way we were calling `stop` on all clips when COGS resets, you can create the following situation:

- Reset in COGS
- AudioPlayer calls `stop` on all clips
- Any clips in `unloaded` state queue up the `stop`
- Now start COGS which plays one of these unloaded clips
- The `stop` event which was queued up fires as soon as the clip loads
- The effect of this is the `stop` callback fires straight away

Feels like a bug, so opened issue on howler repo https://github.com/goldfire/howler.js/issues/1470