### PR TITLE
remove reconnecting-websocket dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@clockworkdog/cogs-client": "^0.11.0",
-    "reconnecting-websocket": "^4.4.0"
+    "@clockworkdog/cogs-client": "^0.11.0"
   },
   "description": "React components and hooks to connect to COGS to build a custom Media Master",
   "repository": {


### PR DESCRIPTION
This is now provided by `@clockworkdog/cogs-client`﻿
