### PR TITLE
Initialise timer to saved timer state

### DIFF
--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -42,10 +42,10 @@ export default function Timer({
     setTimerElapsed(timerElapsed);
   }, [timerTicking, timerStartedAt]);
 
-  const startTimer = useCallback((durationMillis: number) => {
-    setTimerStartedAt(Date.now());
+  const startTimer = useCallback((durationMillis: number, startTime = Date.now(), isTicking = true) => {
+    setTimerStartedAt(startTime);
     setTimerTotalMillis(durationMillis);
-    setTimerTicking(true);
+    setTimerTicking(isTicking);
     setTimerElapsed(0);
   }, []);
 
@@ -70,6 +70,13 @@ export default function Timer({
 
     return;
   }, [timerTicking, updateTimer]);
+
+  useEffect(() => {
+    const timerState = connection.timerState;
+    if (timerState) {
+      startTimer(timerState.durationMillis, timerState.startedAt, timerState.ticking);
+    }
+  }, [connection, startTimer]);
 
   useCogsMessage(
     connection,


### PR DESCRIPTION
Depends on https://github.com/clockwork-dog/cogs-client-lib/pull/23

Here's an example in action where one timer is always rendered and the other is conditionally rendered randomly every second.

---

![two-timer](https://user-images.githubusercontent.com/292958/130107570-76381045-e379-49ea-8e9a-fea2ff05881f.gif)

---

```ts
export default function App() {
  const connection = useCogsConnection();

  const [showSecondTimer, setShowSecondTimer] = useState(false);

  useEffect(() => {
    const interval = setInterval(() => setShowSecondTimer(Math.random() < 0.5), 1000)
    return () => clearInterval(interval)
  }, [])

  return (
  	<div className="App">
  	  <Timer connection={connection} />
  	  {showSecondTimer && <Timer connection={connection} />}
  	</div>
  );
}
```