### PR TITLE
Add an RtspVideo component for displaying RTSP video streams

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
   "cSpell.words": [
     "clockworkdog",
     "fullscreen",
+    "Rtsp",
     "typedoc"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
-    "@clockworkdog/cogs-client": "^1.3.1"
+    "@clockworkdog/cogs-client": "^1.4.0"
   },
   "description": "React components and hooks to connect to COGS to build a custom Media Master",
   "repository": {

--- a/src/components/RtspVideo.tsx
+++ b/src/components/RtspVideo.tsx
@@ -1,0 +1,58 @@
+import { CogsRtspStreamer } from '@clockworkdog/cogs-client';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import usePageVisibility from '../hooks/usePageVisibility';
+
+export interface RtspVideoProps extends React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> {
+  uri: string;
+  websocketHostname?: string;
+  websocketPort?: number;
+  websocketPath?: string;
+}
+
+/**
+ * Takes an RTSP video URL and streams it in a video element. By default this will open the TCP relay
+ * websocket on the same hostname as COGS is running, but can be configured by passing in custom
+ * websocket details.
+ */
+export default function RtspVideo({ uri, websocketHostname, websocketPort, websocketPath, ...rest }: RtspVideoProps): JSX.Element | null {
+  // We need to monitor the page visibility as we only want the stream to play when the page is visible
+  // This is needed because the stream will "pause" when the page looses focus and start playback when it
+  // becomes visible again. This will essentially cause a delay to be introduced into the stream when loosing
+  // page focus. To fix this, we simply stop and restart the stream when the page visibility changes.
+  const isVisible = usePageVisibility();
+
+  // For the video ref we actually use state so useEffect runs when the video ref changes
+  const [videoRef, setVideoRef] = useState<HTMLVideoElement | null>(null);
+  const videoRefCallback = useCallback((newRef: HTMLVideoElement | null) => setVideoRef(newRef), []);
+
+  // Get the RTSP streamer from the COGS provider
+  const rtspStreamer = useMemo(
+    () =>
+      new CogsRtspStreamer({
+        hostname: websocketHostname,
+        port: websocketPort,
+        path: websocketPath,
+      }),
+    [websocketHostname, websocketPath, websocketPort]
+  );
+
+  // An effect which runs when the video element, page visibility, or URIs change
+  // This will start playback of the camera stream in the given element
+  useEffect(() => {
+    // Nothing to do if we don't yet have a video element yet or if the page isn't visible
+    if (!videoRef || !rtspStreamer || !isVisible) {
+      return;
+    }
+
+    const pipeline = rtspStreamer.play({
+      uri,
+      videoElement: videoRef,
+    });
+
+    return () => {
+      pipeline.close();
+    };
+  }, [uri, isVisible, rtspStreamer, videoRef]);
+
+  return <video ref={videoRefCallback} autoPlay {...rest} />;
+}

--- a/src/hooks/usePageVisibility.ts
+++ b/src/hooks/usePageVisibility.ts
@@ -1,0 +1,19 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Uses the Page Visibility API to detect if the page is currently visible to the user.
+ */
+export default function usePageVisibility(): boolean {
+  const [isVisible, setIsVisible] = useState(() => !document.hidden);
+  const onVisibilityChange = useCallback(() => setIsVisible(!document.hidden), []);
+
+  useEffect(() => {
+    document.addEventListener('visibilitychange', onVisibilityChange, false);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  });
+
+  return isVisible;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ export { default as useWhenShowReset } from './hooks/useWhenShowReset';
 export { default as useAudioClips } from './hooks/useAudioClips';
 export { default as useIsAudioPlaying } from './hooks/useIsAudioPlaying';
 
+// RTSP
+export { default as RtspVideo } from './components/RtspVideo';
+
 // Video
 export { default as VideoContainer } from './components/VideoContainer';
 


### PR DESCRIPTION
This depends on `RtspStreamer` in [this PR](https://github.com/clockwork-dog/cogs-client-lib/pull/57) to handle the actual pipeline for the video streaming through the TCP relay websocket and the playback.