### PR TITLE
Allow using `<VideoContainer>` without `<CogsConnectionProvider>`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
   "editor.formatOnSave": true,
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "cSpell.words": [
     "clockworkdog",

--- a/src/components/VideoContainer.tsx
+++ b/src/components/VideoContainer.tsx
@@ -10,12 +10,11 @@ export default function VideoContainer({
 }: {
   className?: string;
   style?: React.CSSProperties;
-  videoPlayer: CogsVideoPlayer | null;
+  videoPlayer?: CogsVideoPlayer | null;
   fullscreen?: boolean | { style: React.CSSProperties };
 }): JSX.Element | null {
   const containerRef = useRef<HTMLDivElement>(null);
-  const providerVideoPlayer = useVideoPlayer();
-  const videoPlayer = customVideoPlayer ?? providerVideoPlayer;
+  const videoPlayer = useVideoPlayer(customVideoPlayer ?? undefined);
 
   useEffect(() => {
     if (videoPlayer && containerRef.current) {

--- a/src/providers/CogsConnectionProvider.tsx
+++ b/src/providers/CogsConnectionProvider.tsx
@@ -3,19 +3,25 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 
 type CogsConnectionContextValue<Manifest extends CogsPluginManifest> = {
   useCogsConnection: () => CogsConnection<Manifest>;
-  useAudioPlayer: () => CogsAudioPlayer | null;
-  useVideoPlayer: () => CogsVideoPlayer | null;
+  useAudioPlayer: (customAudioPlayer?: CogsAudioPlayer) => CogsAudioPlayer | null;
+  useVideoPlayer: (customVideoPlayer?: CogsVideoPlayer) => CogsVideoPlayer | null;
 };
 
 const CogsConnectionContext = React.createContext<CogsConnectionContextValue<any>>({
   useCogsConnection: () => {
     throw new Error('Ensure <CogsConnectionProvider> has been added to your React app');
   },
-  useAudioPlayer: () => {
-    throw new Error('Ensure <CogsConnectionProvider> has been added to your React app');
+  useAudioPlayer: (customAudioPlayer) => {
+    if (!customAudioPlayer) {
+      throw new Error('Ensure <CogsConnectionProvider> has been added to your React app');
+    }
+    return null;
   },
-  useVideoPlayer: () => {
-    throw new Error('Ensure <CogsConnectionProvider> has been added to your React app');
+  useVideoPlayer: (customVideoPlayer) => {
+    if (!customVideoPlayer) {
+      throw new Error('Ensure <CogsConnectionProvider> has been added to your React app');
+    }
+    return null;
   },
 });
 
@@ -134,13 +140,13 @@ export function useCogsConnection<Manifest extends CogsPluginManifest>(): CogsCo
 /**
  * Get the audio player from `<CogsConnectionProvider audioPlayer>`
  */
-export function useAudioPlayer<Manifest extends CogsPluginManifest>(): CogsAudioPlayer | null {
-  return useContext(CogsConnectionContext as React.Context<CogsConnectionContextValue<Manifest>>).useAudioPlayer();
+export function useAudioPlayer<Manifest extends CogsPluginManifest>(customAudioPlayer?: CogsAudioPlayer): CogsAudioPlayer | null {
+  return useContext(CogsConnectionContext as React.Context<CogsConnectionContextValue<Manifest>>).useAudioPlayer(customAudioPlayer);
 }
 
 /**
  * Get the video player from `<CogsConnectionProvider videoPlayer>`
  */
-export function useVideoPlayer<Manifest extends CogsPluginManifest>(): CogsVideoPlayer | null {
-  return useContext(CogsConnectionContext as React.Context<CogsConnectionContextValue<Manifest>>).useVideoPlayer();
+export function useVideoPlayer<Manifest extends CogsPluginManifest>(customVideoPlayer?: CogsVideoPlayer): CogsVideoPlayer | null {
+  return useContext(CogsConnectionContext as React.Context<CogsConnectionContextValue<Manifest>>).useVideoPlayer(customVideoPlayer);
 }


### PR DESCRIPTION
Fixes:

<img width="569" alt="image" src="https://github.com/clockwork-dog/cogs-client-react-lib/assets/292958/26c3167a-ba4d-4812-8420-a99b4b6fa596">

I noticed that the Media Player in COGS does not work with `cogs-client-react` v2 if you don't use `<CogsConnectionProvider>` because of this.

This change allows us to create a `new CogsConnection()` and pass a `CogsVideoPlayer` instance into `<VideoContainer>`:

```tsx
const connection = new CogsConnection(manifest);
const videoPlayer = new CogsVideoPlayer(cogsConnection);

const MyComponent = () => {
  return <VideoContainer videoPlayer={videoPlayer} >
}
